### PR TITLE
cambio nombre cedula por numero documento

### DIFF
--- a/usuarios.html
+++ b/usuarios.html
@@ -34,8 +34,8 @@
             </select>
         </div>
         <div>
-            <label for="cedula">Cedula:</label>
-            <input type="text" id="cedula" name="cedula" class="default">
+            <label for="numerodocumento">Numero Documento:</label>
+            <input type="text" id="numerodocumento" name="numerodocumento" class="default">
         </div>
         <div>
             <label for="genero">Genero:</label>


### PR DESCRIPTION
cambie el nombre de la cedula por numero documento , ya que era necesario para evitar la interracion debido a que es innecesario